### PR TITLE
overrides: add ~/.icons to our filesystem overrides

### DIFF
--- a/flatpak-overrides.in
+++ b/flatpak-overrides.in
@@ -1,5 +1,5 @@
 [Context]
-filesystems=/var/lib/flatpak/runtime/com.endlessm.Clippy.Extension/@FLATPAK_ARCH@/@BRANCH@/active/files:ro;
+filesystems=/var/lib/flatpak/runtime/com.endlessm.Clippy.Extension/@FLATPAK_ARCH@/@BRANCH@/active/files:ro;~/.icons:ro;
 
 [Session Bus Policy]
 com.endlessm.HackSoundServer=talk


### PR DESCRIPTION
We need this so that our custom cursor themes can be exposed to flatpaks.

https://phabricator.endlessm.com/T24413