### PR TITLE
Add hack-data.ini file

### DIFF
--- a/com.endlessm.HackComponents.json.in
+++ b/com.endlessm.HackComponents.json.in
@@ -38,6 +38,7 @@
                 "mkdir -p /app/clippy",
                 "mkdir -p /app/hack-avatar-faces",
                 "mkdir -p /app/share/flatpak-overrides",
+                "install -D -m644 -t /app/share/hack-components hack-data.ini",
                 "chmod +x ./subst",
                 "BRANCH=@BRANCH@ ./subst flatpak-overrides.in /app/share/flatpak-overrides/global"
             ]

--- a/hack-data.ini
+++ b/hack-data.ini
@@ -1,0 +1,6 @@
+[flip-to-hack]
+# This blacklist is for apps that are released along with the core OS; Flatpak
+# apps that we don't control; and Flatpak apps that we do control that cannot be
+# set to NoDisplay=true. It should only be used as a last resort; basically any
+# app with NoDisplay=false should be hackable.
+blacklist=chromium-browser,com.google.Chrome,google-chrome,org.gnome.Eolie,org.gnome.Epiphany,org.mozilla.Firefox,nautilus-classic,org.gnome.Nautilus,org.gnome.Software


### PR DESCRIPTION
This can be used to park any particular data that we don't want to have
to update the core OS for. Right now it is used for a flip-to-hack
blacklist.

Sadly, the GKeyFile parser, unlike the Python .ini parser, does not
allow end-of-line escapes...

In the blacklist we include all browsers, Nautilus, and gnome-software.

https://phabricator.endlessm.com/T24416