### PR TITLE
overrides: Give readwrite access to .icons

### DIFF
--- a/flatpak-overrides.in
+++ b/flatpak-overrides.in
@@ -1,5 +1,5 @@
 [Context]
-filesystems=/var/lib/flatpak/runtime/com.endlessm.Clippy.Extension/@FLATPAK_ARCH@/@BRANCH@/active/files:ro;~/.icons:ro;
+filesystems=/var/lib/flatpak/runtime/com.endlessm.Clippy.Extension/@FLATPAK_ARCH@/@BRANCH@/active/files:ro;~/.icons;
 
 [Session Bus Policy]
 com.endlessm.HackSoundServer=talk


### PR DESCRIPTION
At least one app needs readwrite access (com.endlessm.HackToolbox, so
that it can change the cursor theme), and because this override has
higher priority than the app manifest, all apps must have readwrite
access.

https://phabricator.endlessm.com/T24780