### PR TITLE
Add flip-to-hack whitelist

### DIFF
--- a/hack-data.ini
+++ b/hack-data.ini
@@ -4,3 +4,10 @@
 # set to NoDisplay=true. It should only be used as a last resort; basically any
 # app with NoDisplay=false should be hackable.
 blacklist=chromium-browser,com.google.Chrome,google-chrome,org.gnome.Eolie,org.gnome.Epiphany,org.mozilla.Firefox,nautilus-classic,org.gnome.Nautilus,org.gnome.Software,com.valvesoftware.Steam
+
+# This whitelist is for apps that are explicitly supposed to be hackable in
+# Episode 1. It's only temporary, as the general idea is that everything should
+# be hackable all the time.
+# If the whitelist is empty or not present, then it will be ignored and all apps
+# not in the blacklist will once again be hackable.
+whitelist=com.endlessm.dinosaurs.en,com.endlessm.encyclopedia.en,com.endlessm.Fizzics,com.endlessm.Hackdex_chapter_one,com.endlessm.HackUnlock,com.endlessm.OperatingSystemApp


### PR DESCRIPTION
Intended for Episode 1 only, this whitelist includes all apps that need
to be hackable in Episode 1. In subsequent episodes, all the apps on the
machine should be hackable, so when we fix the issue with the
flip-to-hack button covering up parts of the UI we should empty the
whitelist.

The whitelist is implemented in gnome-shell such that if the key is
empty or not present in the config file, then it will be ignored and all
apps not in the blacklist will be hackable.

https://phabricator.endlessm.com/T24655