### PR TITLE
Add appdata

### DIFF
--- a/data/com.endlessm.HackComponents.appdata.xml
+++ b/data/com.endlessm.HackComponents.appdata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>com.endlessm.HackComponents.desktop</id>
+  <name>Hack Components</name>
+  <summary>Common Hack components</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-2.1</project_license>
+</component>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,6 @@
+data_dir = join_paths(get_option('prefix'), get_option('datadir'))
+
+install_data(
+    'com.endlessm.HackComponents.appdata.xml',
+    install_dir: join_paths(data_dir, 'appdata')
+)

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,8 @@ install_subdir(
     strip_directory: true
 )
 
+subdir('data')
+
 meson.add_install_script(
     'mkdir', '-p',
     join_paths(get_option('prefix'), 'clippy'),


### PR DESCRIPTION
GNOME Software relies heavily on the AppStream/appdata for managing
apps, so we make sure that the HackComponents app has the appdata.

https://phabricator.endlessm.com/T26020