### PR TITLE
Make the sketchbook hackable

### DIFF
--- a/hack-data.ini
+++ b/hack-data.ini
@@ -10,4 +10,4 @@ blacklist=chromium-browser,com.google.Chrome,google-chrome,org.gnome.Eolie,org.g
 # be hackable all the time.
 # If the whitelist is empty or not present, then it will be ignored and all apps
 # not in the blacklist will once again be hackable.
-whitelist=com.endlessm.dinosaurs.en,com.endlessm.encyclopedia.en,com.endlessm.Fizzics,com.endlessm.Hackdex_chapter_one,com.endlessm.Hackdex_chapter_two,com.endlessm.HackUnlock,com.endlessm.LightSpeed,com.endlessm.OperatingSystemApp,com.endlessm.Sidetrack
+whitelist=com.endlessm.dinosaurs.en,com.endlessm.encyclopedia.en,com.endlessm.Fizzics,com.endlessm.Hackdex_chapter_one,com.endlessm.Hackdex_chapter_two,com.endlessm.HackUnlock,com.endlessm.LightSpeed,com.endlessm.OperatingSystemApp,com.endlessm.Sidetrack,com.endlessm.Sketchbook


### PR DESCRIPTION
It also has X-Endless-Hackable in its desktop file, but this should
allow it to run on 3.6 where gnome-shell still needs this list to
determine what's hackable.

https://phabricator.endlessm.com/T26912